### PR TITLE
Add a Dockerfile for deploying to DigitalOcean apps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: monthly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM wordpress:5.7.1
+COPY org.whatwg.awesome /var/www/html/wp-content/themes/org.whatwg.awesome/


### PR DESCRIPTION
This doesn't yet have our plugins or any other customizations. Our plugins are apparently:

- http://benjamin.smedbergs.us/wordpress-atom-1.0/
- https://wordpress.org/plugins/classic-editor/
- https://plugins.trac.wordpress.org/wiki/TextControl

Of these the Atom plugin seems somewhat important as if we fail to add it then the feeds will get regenerated as RSS 2.0 which will make peoples' feed readers get new entries, probably. The other two I suspect are not crucial and we could figure out a way to get raw-HTML editing experience with the default UI.

On the Atom plugin: maybe we should just omit it. Not having to deal with plugins seems nice. It's a bit weird that it exists since  [Atom is built-in to WordPress](https://wordpress.org/support/article/wordpress-feeds/). I guess it probably hijacks `rss2_url` to give Atom, instead of RSS2?