### PR TITLE
Fix HTTP header setting

### DIFF
--- a/org.whatwg.awesome/functions.php
+++ b/org.whatwg.awesome/functions.php
@@ -11,9 +11,10 @@ remove_filter('the_excerpt', 'wptexturize');
 // Keep (mostly) in sync with https://github.com/whatwg/misc-server and
 // https://github.com/whatwg/participate.whatwg.org.
 add_action('send_headers', function() {
-  header('strict-transport-security', 'max-age=63072000; includeSubDomains; preload');
-  header('x-content-type-options', 'nosniff');
-  header('x-frame-options', 'sameorigin');
+  header('strict-transport-security: max-age=63072000; includeSubDomains; preload');
+  header('x-content-type-options: nosniff');
+  header('x-frame-options: sameorigin');
+  header_remove('x-powered-by');
 });
 
 if ( function_exists('register_sidebar') )


### PR DESCRIPTION
Also remove x-powered-by.

Still not tested since local testing is slightly hard and I suspect this is an easy fix...

I'll note that this only sets headers on PHP generated pages, and not on static resources. To do that maybe we'd copy some htaccess files into the appropriate place on the server.