### PR TITLE
Bump WordPress and PHP versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM wordpress:5.9.1
+FROM wordpress:5.9.2-php8.1-fpm
 COPY org.whatwg.awesome /var/www/html/wp-content/themes/org.whatwg.awesome/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM wordpress:5.9.2-php8.1-fpm
+FROM wordpress:5.9.2-php8.1
 COPY org.whatwg.awesome /var/www/html/wp-content/themes/org.whatwg.awesome/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM wordpress:5.9.2-php8.1
+FROM wordpress:5.9.2-php8.1-apache
 COPY org.whatwg.awesome /var/www/html/wp-content/themes/org.whatwg.awesome/


### PR DESCRIPTION
This is in some vague hope that since PHP 8 advertises speed improvements over PHP 7, this will reduce server load and thus help with our downtime.